### PR TITLE
Support path prefix.

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,4 +1,5 @@
 const rssPlugin = require('@11ty/eleventy-plugin-rss');
+const { EleventyHtmlBasePlugin } = require("@11ty/eleventy");
 // Filters
 const dateFilter = require('./src/filters/date-filter.js');
 const w3DateFilter = require('./src/filters/w3-date-filter.js');
@@ -69,6 +70,8 @@ module.exports = config => {
   }
 
   // Plugins
+  config.addPlugin(EleventyHtmlBasePlugin);
+
   config.addPlugin(rssPlugin);
 
 
@@ -90,6 +93,7 @@ module.exports = config => {
         .map((linkedAgentTypeName) => ({
           title: linkedAgentTypeName,
           slug: strToSlug(linkedAgentTypeName),
+          link: "/" + process.env.linkedAgentPath + "/" + strToSlug(linkedAgentDatabaseName + "/" + strToSlug(linkedAgentTypeName)) + "/index.html",
           collectionName: "linkedAgent_" + strToSlug(linkedAgentDatabaseName + "_" + strToSlug(linkedAgentTypeName))
         }));
     });
@@ -108,6 +112,7 @@ module.exports = config => {
           linkedAgentNamespace: linkedAgentDatabaseName,
           linkedAgentType: linkedAgentTypeName,
           linkedAgentTypeSlug: strToSlug(linkedAgentTypeName),
+          link: "/" + process.env.linkedAgentPath + "/" + strToSlug(linkedAgentDatabaseName + "/" + strToSlug(linkedAgentTypeName)) + "/" + islandtyHelpers.strToSlug(name) + "/index.html",
           slug: islandtyHelpers.strToSlug(name),
         }));
 
@@ -140,6 +145,7 @@ module.exports = config => {
 
     var linkedAgentNamespaceCollection = linkedAgentNamespaces.map((linkedAgentNamespace) => ({
       title: linkedAgentNamespace,
+      link: "/" + process.env.linkedAgentPath + "/" + strToSlug(linkedAgentNamespace) + "/index.html",
       slug: strToSlug(linkedAgentNamespace),
       collectionName: "linkedAgent_" + strToSlug(linkedAgentNamespace),
       permalinkBase: path.join(process.env.linkedAgentPath, strToSlug(linkedAgentNamespace))
@@ -205,6 +211,7 @@ module.exports = config => {
   config.amendLibrary("md", mdLib => mdLib.enable("code"));
   config.addGlobalData('contentPath', process.env.contentPath);
   config.addGlobalData('linkedAgentPath', process.env.linkedAgentPath);
+  config.addGlobalData('pathPrefix', process.env.pathPrefix);
 
   // Add configurations at the top-level into Eleventy.
   siteConfig = require('./config/site.json');
@@ -221,6 +228,7 @@ module.exports = config => {
     markdownTemplateEngine: 'njk',
     dataTemplateEngine: 'njk',
     htmlTemplateEngine: 'njk',
+    pathPrefix: process.env.pathPrefix,
     dir: {
       input: 'src',
       output: 'dist'

--- a/src/_data/islandtyHelpers.js
+++ b/src/_data/islandtyHelpers.js
@@ -94,7 +94,8 @@ module.exports = {
    *    The path of the manifest.
    */
   getIiifManifestForItem(file) {
-    let manifest_url = path.join(path.dirname(file), 'iiif/index.json');
+    const pathPrefix = process.env.pathPrefix ? process.env.pathPrefix : '/';
+    let manifest_url = path.join(pathPrefix, path.dirname(file), 'iiif/index.json');
     return manifest_url;
   },
 

--- a/src/_data/islandtyHelpers.js
+++ b/src/_data/islandtyHelpers.js
@@ -95,7 +95,7 @@ module.exports = {
    */
   getIiifManifestForItem(file) {
     const pathPrefix = process.env.pathPrefix ? process.env.pathPrefix : '/';
-    let manifest_url = path.join(pathPrefix, path.dirname(file), 'iiif/index.json');
+    let manifest_url = path.join("/", pathPrefix, path.dirname(file), 'iiif/index.json');
     return manifest_url;
   },
 

--- a/src/_includes/partials/linked-agent-list.html
+++ b/src/_includes/partials/linked-agent-list.html
@@ -4,8 +4,10 @@
 
 		{% endif %}
 
+
 		<li>
-			<a href="{{ relatorItem.slug }}">{{ relatorItem.title }}</a>
+		{{ relatorItem | debug }}
+			<a href="{{ relatorItem.link }}">{{ relatorItem.title }}</a>
 		</li>
 
 		{% if loop.last %}

--- a/src/_includes/partials/mirador.html
+++ b/src/_includes/partials/mirador.html
@@ -1,8 +1,10 @@
 {% set manifest = islandtyHelpers.getIiifManifestForItem(file) %}
+
 <script src="https://roblib.github.io/mirador-integration-islandora/islandora-mirador-0.1.0.js"></script>
 <!-- By default uses Roboto font. Be sure to load this or change the font -->
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
 <!-- Container element of Mirador whose id should be passed to the instantiating call as "id" -->
+
 <div id="box" style="position: relative;">
     <div id="bounding-box" style="height:800px;"></div>
     <div id="my-mirador"></div>

--- a/src/islandty/ContentModels/PagedContent.js
+++ b/src/islandty/ContentModels/PagedContent.js
@@ -72,7 +72,7 @@ module.exports = {
       const prefix = process.env.pathPrefix;
       const pathPrefix = prefix ? prefix : '/';
 
-      buildIiif(iiifPath, process.env.serverHost + pathPrefix + process.env.contentPath + '/' + item.id + '/iiif');
+      buildIiif(iiifPath, process.env.serverHost + path.join('/', pathPrefix, process.env.contentPath, item.id, 'iiif'));
     }
     defaultContentModel.ingest(item, inputMediaPath, outputDir);
   },

--- a/src/islandty/ContentModels/PagedContent.js
+++ b/src/islandty/ContentModels/PagedContent.js
@@ -69,7 +69,10 @@ module.exports = {
       // Generate the IIIF manifest and tiles with Biiif.
       let iiifPath = path.join(outputDir, 'iiif');
       generateIiifMetadata(item, iiifPath);
-      buildIiif(iiifPath, process.env.serverHost + '/' + process.env.contentPath + '/' + item.id + '/iiif');
+      const prefix = process.env.pathPrefix;
+      const pathPrefix = prefix ? prefix : '/';
+
+      buildIiif(iiifPath, process.env.serverHost + pathPrefix + process.env.contentPath + '/' + item.id + '/iiif');
     }
     defaultContentModel.ingest(item, inputMediaPath, outputDir);
   },

--- a/src/islandty/ContentModels/PublicationIssue.js
+++ b/src/islandty/ContentModels/PublicationIssue.js
@@ -72,7 +72,7 @@ module.exports = {
       const prefix = process.env.pathPrefix;
       const pathPrefix = prefix ? prefix : '/';
 
-      buildIiif(iiifPath, process.env.serverHost + pathPrefix + process.env.contentPath + '/' + item.id + '/iiif');
+      buildIiif(iiifPath, process.env.serverHost + path.join('/', pathPrefix, process.env.contentPath, item.id, 'iiif'));
     }
     defaultContentModel.ingest(item, inputMediaPath, outputDir);
   },

--- a/src/islandty/ContentModels/PublicationIssue.js
+++ b/src/islandty/ContentModels/PublicationIssue.js
@@ -69,7 +69,10 @@ module.exports = {
       // Generate the IIIF manifest and tiles with Biiif.
       let iiifPath = path.join(outputDir, 'iiif');
       generateIiifMetadata(item, iiifPath);
-      buildIiif(iiifPath, process.env.serverHost + '/' + process.env.contentPath + '/' + item.id + '/iiif');
+      const prefix = process.env.pathPrefix;
+      const pathPrefix = prefix ? prefix : '/';
+
+      buildIiif(iiifPath, process.env.serverHost + pathPrefix + process.env.contentPath + '/' + item.id + '/iiif');
     }
     defaultContentModel.ingest(item, inputMediaPath, outputDir);
   },


### PR DESCRIPTION
For things like GitHub Pages, we want to support having a prefix before the paths.

Eleventy handles this gracefully for the most part using the Base URL plugin, but there are exceptions:

- IIIF Manifest URLs need to be checked manually
- Linked agent paths need to be re-vamped.

This PR makes it so Prefix Paths work.