### PR TITLE
Display parent field as a link to the parent

### DIFF
--- a/src/_data/islandtyFieldInfo.json
+++ b/src/_data/islandtyFieldInfo.json
@@ -17,7 +17,13 @@
     },
     "field_member_of": {
         "label": "Member Of",
-        "cardinality": "-1"
+        "cardinality": "-1",
+        "metadata_display": false
+    },
+    "parent_id": {
+        "label": "Parent",
+        "cardinality": "-1",
+        "type": "reference"
     },
     "field_weight": {
         "label": "Weight",

--- a/src/_data/islandtyHelpers.js
+++ b/src/_data/islandtyHelpers.js
@@ -34,8 +34,8 @@ module.exports = {
    *   The property value.
    */
   getNested(obj, ...args) {
-  return args.reduce((obj, level) => obj && obj[level], obj)
-},
+    return args.reduce((obj, level) => obj && obj[level], obj)
+  },
 
   /**
      * Finds the parent item from the current item
@@ -116,7 +116,7 @@ module.exports = {
 
   searchIndex(article) {
     let isString = value => typeof value === 'string' || value instanceof String;
-    let getIndexValue = function(value, result = '') {
+    let getIndexValue = function (value, result = '') {
       if (!(isString(value))) {
         for (key in value) {
           result += key;
@@ -124,7 +124,7 @@ module.exports = {
           result += getIndexValue(value[key])
         }
       }
-      else{
+      else {
         result += value;
         result += ' '
       }
@@ -179,8 +179,8 @@ module.exports = {
   transformKeys(obj) {
     fieldInfo = require('./islandtyFieldInfo.json');
 
-// Add permalink field.
-obj['permalink'] = '/' + process.env.contentPath + '/' + obj.id + '/index.html';
+    // Add permalink field.
+    obj['permalink'] = '/' + process.env.contentPath + '/' + obj.id + '/index.html';
 
     const newObj = { item: {} };
 
@@ -210,11 +210,11 @@ obj['permalink'] = '/' + process.env.contentPath + '/' + obj.id + '/index.html';
   parseLinkedAgent(values) {
     var valuesArray;
     var parsedRelations = {};
-    if (typeof(values) == 'string') {
+    if (typeof (values) == 'string') {
       if (values.length == 0) {
         valuesArray = [];
       }
-      else  {
+      else {
         valuesArray = [values];
       }
     }
@@ -258,46 +258,46 @@ obj['permalink'] = '/' + process.env.contentPath + '/' + obj.id + '/index.html';
    * @param {String} key - key to get values from
    */
   getAllKeyValues(collectionArray, key) {
-  // get all values from collection
-  let allValues = collectionArray.map((item) => {
-    let values = item.data[key] ? item.data[key] : [];
-    return values;
-  });
+    // get all values from collection
+    let allValues = collectionArray.map((item) => {
+      let values = item.data[key] ? item.data[key] : [];
+      return values;
+    });
 
-  // flatten values array
-  allValues = lodash.flattenDeep(allValues);
-  // to lowercase
-  allValues = allValues.map((item) => item.toLowerCase());
-  // remove duplicates
-  allValues = [...new Set(allValues)];
-  // order alphabetically
-  allValues = allValues.sort(function (a, b) {
-    return a.localeCompare(b, "en", { sensitivity: "base" });
-  });
-  // return
-  return allValues;
-},
+    // flatten values array
+    allValues = lodash.flattenDeep(allValues);
+    // to lowercase
+    allValues = allValues.map((item) => item.toLowerCase());
+    // remove duplicates
+    allValues = [...new Set(allValues)];
+    // order alphabetically
+    allValues = allValues.sort(function (a, b) {
+      return a.localeCompare(b, "en", { sensitivity: "base" });
+    });
+    // return
+    return allValues;
+  },
 
-linkedAgentUrl(namespace, type, name) {
-  return '/' + path.join(process.env.linkedAgentPath, this.strToSlug(namespace), this.strToSlug(type), this.strToSlug(name));
+  linkedAgentUrl(namespace, type, name) {
+    return '/' + path.join(process.env.linkedAgentPath, this.strToSlug(namespace), this.strToSlug(type), this.strToSlug(name));
 
-},
+  },
 
-/**
- * Transform a string into a slug
- * Uses slugify package
- *
- * @param {String} str - string to slugify
- */
-strToSlug(str) {
-  const options = {
-    replacement: "-",
-    remove: /[&,+()$~%.'":*?<>{}]/g,
-    lower: true,
-  };
+  /**
+   * Transform a string into a slug
+   * Uses slugify package
+   *
+   * @param {String} str - string to slugify
+   */
+  strToSlug(str) {
+    const options = {
+      replacement: "-",
+      remove: /[&,+()$~%.'":*?<>{}]/g,
+      lower: true,
+    };
 
-  return slugify(str, options);
-}
+    return slugify(str, options);
+  }
 
 
 

--- a/src/_data/islandtyHelpers.js
+++ b/src/_data/islandtyHelpers.js
@@ -112,6 +112,24 @@ module.exports = {
     return filteredItems;
   },
 
+  /**
+   * Get all content items with the given fieldname equal to the given value).
+   *
+   * @param {*} items
+   * @param {*} fieldname
+   * @param {*} model
+   * @returns
+   */
+  itemsWithFieldValue(items, fieldname, value) {
+    fieldInfo = require('./islandtyFieldInfo.json');
+    field = fieldInfo[fieldname]
+    if (field.cardinality == "1") {
+      return items.filter(x => x[fieldname] == value);
+    }
+    else {
+      return items.filter(x => value in x[fieldname]);
+    }
+  },
 
 
   searchIndex(article) {
@@ -280,7 +298,6 @@ module.exports = {
 
   linkedAgentUrl(namespace, type, name) {
     return '/' + path.join(process.env.linkedAgentPath, this.strToSlug(namespace), this.strToSlug(type), this.strToSlug(name));
-
   },
 
   /**

--- a/src/_includes/partials/field-formatter-reference.html
+++ b/src/_includes/partials/field-formatter-reference.html
@@ -1,0 +1,16 @@
+{% set targets = item[name] %}
+{% set count = targets.length %}
+
+{% for target in targets %}
+
+{% set targetItem = islandtyHelpers.itemsWithFieldValue(readCSV.items, 'id', target)[0] %}
+    
+    <tr>
+        {% if loop.first %}
+        <th rowspan="{{ count }}">{{ islandtyFieldInfo[name]['label'] }}</th>
+        {% endif %}
+        <td>
+            <a href="/{{ contentPath }}/{{ targetItem.id | slugify }}">{{ targetItem.title }}</a>
+        </td>
+    </tr>
+{% endfor %}

--- a/src/_includes/partials/metadata.html
+++ b/src/_includes/partials/metadata.html
@@ -9,6 +9,8 @@
                 {% include "partials/field-formatter-linked-agent.html" %}
                 {% elif 'type' in field and field['type'] == 'subject' %}
                 {% include "partials/field-formatter-subject.html" %}
+                {% elif 'type' in field and field['type'] == 'reference' %}
+                {% include "partials/field-formatter-reference.html" %}
                 {% else %}
                     {% if item[name] is string %}
                         <tr><th scope="row">{{ field.label }}</th><td>{{ item[name] | safe }}</td></tr>


### PR DESCRIPTION
Render a field containing the id of another item as a link to said item. The value in the referring field must be in the `id` column of the spreadsheet.

We didn't use `field_member_of` because it was not populated in islandora_demo_objects. however, `parent_id` is. 

* adds a new function in islandtyHelpers that returns a filtered list of the CSV items, filtered by whether a specified field contains a given value.
* added another field type-based if statement to the metadata partial.
* added another partial for reference fields that uses the islandtyHelpers function and renders the matching item(s)
* added field config to tell islandty about parent_id, that it's a reference field, and to not show field_member_of.
