### PR TITLE
Fix #45 name collisions.

### DIFF
--- a/src/_data/islandtyHelpers.js
+++ b/src/_data/islandtyHelpers.js
@@ -3,8 +3,7 @@ const path = require('path');
 const SaxonJS = require('saxon-js');
 require('dotenv').config();
 const slugify = require('slugify');
-
-
+const slugifyWithCounter = require('@sindresorhus/slugify').slugifyWithCounter();
 
 module.exports = {
 
@@ -415,8 +414,22 @@ module.exports = {
     };
 
     return slugify(str, options);
-  }
+  },
 
+   /**
+   * Transform a string into a slug
+   * Uses slugify package
+   *
+   * @param {String} str - string to slugify
+   */
+   strToSlugWithCounter(str) {
+    const options = {
+      replacement: "-",
+      remove: /[&,+()$~%.'":*?<>{}]/g,
+      lower: true,
+    };
 
+    return slugifyWithCounter(str, options);
+  },
 
 }

--- a/src/_includes/partials/field-formatter-linked-agent.html
+++ b/src/_includes/partials/field-formatter-linked-agent.html
@@ -1,6 +1,8 @@
 {% set linked_agents = item[name] %}
 {% for relType, relData in linked_agents %}
+
   {% for rel, contributors in relData %}
+  {%- set relCollection =  collections['linkedAgent_' + relType + '_' + rel|slugify ] -%}
 
   {% set count = contributors.length %}
 
@@ -11,7 +13,7 @@
         {% endif %}
 
         <td>
-<a href="{{ islandtyHelpers.linkedAgentUrl(relType, rel, contributor)}}">{{ contributor }}</a>
+<a href="{{ relCollection|getLinkFromTitle(contributor) }}">{{ contributor }}</a>
 
         </td>
     </tr>

--- a/src/islandty/commands/readCSV.js
+++ b/src/islandty/commands/readCSV.js
@@ -73,10 +73,13 @@ async function main() {
               }
 
               if (!allLinkedAgents[linkedAgentType][linkedAgentName][linkedAgentValue]) {
-                allLinkedAgents[linkedAgentType][linkedAgentName][linkedAgentValue] = [];
+                allLinkedAgents[linkedAgentType][linkedAgentName][linkedAgentValue] = {
+                  nameSlug: islandtyHelpers.strToSlugWithCounter(linkedAgentValue),
+                  values: []
+                };
               }
 
-              allLinkedAgents[linkedAgentType][linkedAgentName][linkedAgentValue].push(transformedItem.id);
+              allLinkedAgents[linkedAgentType][linkedAgentName][linkedAgentValue]['values'].push(transformedItem.id);
             }
           }
         }


### PR DESCRIPTION
Fixes issue #45 by:
* using "slugifyWithCounter" when building the linked agent database
* storing the "nameSlug" under the name in the linked agent database, along with the values (pushing them one level deeper in the array)
* creating a filter that takes a collection and title and finds the stored link field of the element of the collection whose title matches the title provided
* using that filter in the linked agent template.