### PR TITLE
Ocfl Support

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,9 @@
 contentPath=islandora/object
 linkedAgentPath=linked-agent
-dataFileName=../islandora_demo_objects/create_islandora_objects.csv
+dataFileName=../islandora_demo_objects/simple_object.csv
 inputMediaPath=../islandora_demo_objects
 serverHost="http://localhost:8080"
 outputDir=web
 CSVOverrideFieldInfo=true
 USE_LOCAL_MIRADOR=true
+ storageConfig={"ocfl": true, "root": "/path/to/ocfl/root", "layout": "FlatDirectStorageLayout"}

--- a/.env
+++ b/.env
@@ -1,5 +1,6 @@
 contentPath=islandora/object
 linkedAgentPath=linked-agent
+#dataFileName=../islandora_demo_objects/simple_object.csv
 dataFileName=../islandora_demo_objects/create_islandora_objects.csv
 inputMediaPath=../islandora_demo_objects
 serverHost="http://localhost:8080"

--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 contentPath=islandora/object
 linkedAgentPath=linked-agent
-dataFileName=../islandora_demo_objects/simple_object.csv
+dataFileName=../islandora_demo_objects/create_islandora_objects.csv
 inputMediaPath=../islandora_demo_objects
 serverHost="http://localhost:8080"
 outputDir=web

--- a/.env
+++ b/.env
@@ -6,4 +6,4 @@ serverHost="http://localhost:8080"
 outputDir=web
 CSVOverrideFieldInfo=true
 USE_LOCAL_MIRADOR=true
- storageConfig={"ocfl": true, "root": "/path/to/ocfl/root", "layout": "FlatDirectStorageLayout"}
+ storageConfig={"ocfl": true, "layout": "FlatDirectStorageLayout"}

--- a/.env
+++ b/.env
@@ -7,4 +7,4 @@ serverHost="http://localhost:8080"
 outputDir=web
 CSVOverrideFieldInfo=true
 USE_LOCAL_MIRADOR=true
- storageConfig={"ocfl": true, "layout": "FlatDirectStorageLayout"}
+ ocfl=true

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ you can use the same input files to generate a static website.
 
 ## Features
 
+- OCFL - All objects are stored as single OCFL objects. Changing files automatically results in a new OCFL version being minted.
 - MODS support
 - Mirador viewer with embedded hOCR
 - Content-model based system that moves files into place and can be used to generate derivatives.
@@ -116,20 +117,35 @@ The value is an array that can contain the following elements:
 * `"type"`: Optional. It may be either
 	* `"typed_relation"`: parse the field using Workbench's Typed Relation protocols
  	* `"subject"`: parse the field as though it is a Workbench Taxonomy Term.
-	  In your data, a vocabulary may be prepended to the term with a colon 
-	  (e.g. `field_model:Image`) and Islandty will only display the term (e.g. "Image"). This type option will not work for terms that contain 
-	  colons. This type option also populates the metadata table with a 
+	  In your data, a vocabulary may be prepended to the term with a colon
+	  (e.g. `field_model:Image`) and Islandty will only display the term (e.g. "Image"). This type option will not work for terms that contain
+	  colons. This type option also populates the metadata table with a
 	  multi-row header if the field is multi-valued.
-  	* `"file"`: Required if intending to use this file in Islandty. By 
-	  default, it will render a downloadable file link in the metadata table. 
-	    See also: 
+  	* `"file"`: Required if intending to use this file in Islandty. By
+	  default, it will render a downloadable file link in the metadata table.
+	    See also:
 	  the `"metadata_display"` option and the `"downloadable"` option.
   	* If empty, fields will be treated as strings.
 * `"metadata_display"` Optional, defaults to `true`. If `false` (or if the column is not listed in
 this file), then the values will not be displayed in the metadata table.
-* `"downloadable"` Optional, defaults to `false`. Render a downloadable file 
+* `"downloadable"` Optional, defaults to `false`. Render a downloadable file
   link in a "File Downloads" section below the metadata.
 The metadata table will be populated in the order that fields appear in this file.
+
+#### Islandora Workbench Field Metadata
+
+If you used the export_csv Islandora Workbench command,
+then field data will have been exported at the top of the CSV file.
+
+Islandty uses this data instead if it exists.
+
+This is enabled by setting:
+
+```ini
+CSVOverrideFieldInfo=true
+```
+
+in your .env file.
 
 ### Generate and run the site locally.
 
@@ -147,7 +163,7 @@ Add a `mods` column to the CSV input data file
 to have Islandty include MODS data in the
 object's metadata section directly. This lets you avoid
 having to extract all of those fields
-to CSV columns if your source metadata is in MODS format. 
+to CSV columns if your source metadata is in MODS format.
 Islandty uses an XSLT to extract metadata for display.
 
 ## hOCR support

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,4 +1,4 @@
-### Environment and Configuration
+# Environment and Configuration
 
 Settings live in two places:
 
@@ -7,14 +7,14 @@ Settings live in two places:
 
 The .env file may contain the following entries:
 
-```contentPath=islandora/object```
+## ```contentPath=islandora/object```
 
 The URL path prefixing the object's id.
 
 E.g., if contentPath is set to 'islandora/object', an object who's Id is "newspapers-233" would
 then have the path /islandora/object/newspapers-233.
 
-```linkedAgentPath=linked-agent```
+## ```linkedAgentPath=linked-agent```
 
 This is the path prefix for all linked agent
 listings pages.
@@ -27,7 +27,7 @@ with that author would appear at:
 
 /linked-agent/relators/author/l-m-montgomery
 
-```dataFileName=../islandora_demo_objects/create_islandora_objects.csv```
+## ```dataFileName=../islandora_demo_objects/create_islandora_objects.csv```
 
 The location of the CSV file that Islandty reads.
 
@@ -36,7 +36,7 @@ It does not need to be in the same folder as your input media files.
 It can also be a Google Sheets spreadsheet's public
 sharing URL.
 
-```inputMediaPath=../islandora_demo_objects```
+## ```inputMediaPath=../islandora_demo_objects```
 
 This is the folder containing
 the files that will get ingested into Islandty.
@@ -44,18 +44,31 @@ the files that will get ingested into Islandty.
 The paths listed in the input data file
 are relative to this directory.
 
-```serverHost="http://localhost:8080"```
+## ```serverHost="http://localhost:8080"```
 
 The base URL where the site will be served from.
 
-```outputDir=web```
+## ```outputDir=web```
 
 The directory name where the HTML and supporting
 files will be written to on disck.
 
 
-```CSVOverrideFieldInfo```
+## ```CSVOverrideFieldInfo```
 
 The Islandora Workbench 'export_csv' task will autment the CSV with metadata about each field, specifically a Label and the Cardinality.  If this setting is set to 'true', these values in the CSV will supercede the values in config/islandtyFieldInfo.json.
 
-If set to 'false', or if no field metdata is present in the CSV, islandtyFieldINfo.json will be used.
+If set to 'false', or if no field metadata is present in the CSV, islandtyFieldINfo.json will be used.
+
+## ```ocfl=true```
+
+When set to true, objects will be placed into an [Oxford Common File Layout](https://ocfl.io)-conformant folder structure.
+
+When a file has been modified, a new version of the OCFL object
+will be minted, and the old one will remain in place.
+
+When set to false, all objects will simply
+be copied to the same output path
+as under the object's ID beneath the configured
+contentPath setting.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@11ty/eleventy-cache-assets": "^2.3.0",
         "@11ty/eleventy-plugin-rss": "^2.0.3",
+        "@ocfl/ocfl-fs": "^0.2.2",
         "biiif": "github:alxp/biiif#master-dist",
         "concurrently": "^9.1.2",
         "csv": "^6.3.8",
@@ -829,6 +830,27 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@ocfl/ocfl": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@ocfl/ocfl/-/ocfl-0.2.2.tgz",
+      "integrity": "sha512-q3Ze2/wnY8Anbkn5fQH2f+JHyy4n7Gw2/VO6TNdfkvH4U6E8wViCRoO9k8g8H6Vvya0MTzqY1ja+mevE7KyLwg==",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "hash-wasm": "^4.11.0"
+      },
+      "engines": {
+        "node": ">=17.0.0"
+      }
+    },
+    "node_modules/@ocfl/ocfl-fs": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@ocfl/ocfl-fs/-/ocfl-fs-0.2.2.tgz",
+      "integrity": "sha512-y3QmR9/D4PXnk/MYqf0+XWydtKMTuLdT5ugO/XffxZJi6K39cZrYJjVDADRLGy8T9c84FBFH2jQk22gX7pBL/Q==",
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@ocfl/ocfl": "0.2.2"
       }
     },
     "node_modules/@parcel/watcher": {
@@ -3400,6 +3422,12 @@
       "resolved": "https://registry.npmjs.org/hash-string/-/hash-string-1.0.0.tgz",
       "integrity": "sha512-dtNNyxXobzHavayZwOwRWhBTqS9GX4jDjIMsGc0fDyaN2A+4zMn5Ua9ODDCggN6w3Spma6mAHL3ImmW3BkWDmQ==",
       "license": "ISC"
+    },
+    "node_modules/hash-wasm": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/hash-wasm/-/hash-wasm-4.12.0.tgz",
+      "integrity": "sha512-+/2B2rYLb48I/evdOIhP+K/DD2ca2fgBjp6O+GBEnCDk2e4rpeXIK8GvIyRPjTezgmWn9gmKwkQjjx6BtqDHVQ==",
+      "license": "MIT"
     },
     "node_modules/hasown": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@11ty/eleventy-cache-assets": "^2.3.0",
     "@11ty/eleventy-plugin-rss": "^2.0.3",
+    "@ocfl/ocfl-fs": "^0.2.2",
     "biiif": "github:alxp/biiif#master-dist",
     "concurrently": "^9.1.2",
     "csv": "^6.3.8",

--- a/src/_data/islandtyHelpers.js
+++ b/src/_data/islandtyHelpers.js
@@ -129,7 +129,7 @@ module.exports = {
 
     // Check x.data.parent_id if it exists
     const parentId2 = x.data?.parent_id;
-    const parentId2Valid = parentId2 && typeof parentId2 === 'string' && parentId2.includes(item_id);
+    const parentId2Valid = parentId2 && typeof parentId2 === 'object' && parentId2.includes(item_id);
 
     // Return true if either condition is met
     return parentId1Valid || parentId2Valid;

--- a/src/_data/islandtyHelpers.js
+++ b/src/_data/islandtyHelpers.js
@@ -195,10 +195,10 @@ module.exports = {
     fieldInfo = require('../../config/islandtyFieldInfo.json');
     field = fieldInfo[fieldname]
     if (field.cardinality == "1") {
-      return items.filter(x => x[fieldname] == value);
+      return items.filter(x => x['data'][fieldname] == value);
     }
     else {
-      return items.filter(x => value in x[fieldname]);
+      return items.filter(x => value in x['data'][fieldname]);
     }
   },
 

--- a/src/_data/islandtyHelpers.js
+++ b/src/_data/islandtyHelpers.js
@@ -204,6 +204,8 @@ module.exports = {
 
 
   searchIndex(article) {
+const fullTextFileFields = ['extracted'];
+
     let isString = value => typeof value === 'string' || value instanceof String;
     let getIndexValue = function (value, result = '') {
       if (!(isString(value))) {
@@ -214,7 +216,12 @@ module.exports = {
         }
       }
       else {
-        result += value;
+        if (fullTextFileFields.includes(key) && value !== '') {
+          result += fs.readFileSync(path.join(process.env.outputDir, value), { encoding: 'utf8' });
+        }
+        else {
+          result += value;
+        }
         result += ' '
       }
       return result;

--- a/src/_data/islandtyHelpers.js
+++ b/src/_data/islandtyHelpers.js
@@ -49,6 +49,7 @@ module.exports = {
       return newRecord;
     });
   },
+
   generateIiifMetadata(book, bookPath) {
     const writeYamlFile = require('write-yaml-file');
     info = {
@@ -128,7 +129,7 @@ module.exports = {
 
     // Check x.data.parent_id if it exists
     const parentId2 = x.data?.parent_id;
-    const parentId2Valid = parentId2 && typeof parentId2 === 'object' && parentId2.includes(item_id);
+    const parentId2Valid = parentId2 && typeof parentId2 === 'string' && parentId2.includes(item_id);
 
     // Return true if either condition is met
     return parentId1Valid || parentId2Valid;

--- a/src/_data/islandtyHelpers.js
+++ b/src/_data/islandtyHelpers.js
@@ -253,7 +253,6 @@ module.exports = {
    * Also gives content models a chance to modify the data.
    */
   objectIndexMetadata(items, object) {
-    console.log("lunr debug, object ID: " + object.data.id);
     if (object.data.field_model == 'Page') {
       const parent = this.getParentContent(items, object.data.parent_id);
       let page = object.data.field_weight;

--- a/src/_includes/partials/Newspaper.html
+++ b/src/_includes/partials/Newspaper.html
@@ -12,7 +12,12 @@
     <h2>Children</h2>
     <ul>
         {% for child in children %}
-        <li><a href="/{{ contentPath }}/{{ child.id | slugify }}">{{ child.title }}</a></li>
+<li>
+	<a href="/{{ contentPath }}/{{ child.data.id | slugify }}">{{ child.data.title }}</a>
+</li>
+
+</li>
+
         {% endfor %}
     </ul>
 </div>

--- a/src/_includes/partials/field-formatter-reference.html
+++ b/src/_includes/partials/field-formatter-reference.html
@@ -10,7 +10,7 @@
 			<th rowspan="{{ count }}">{{ islandtyFieldInfo[name]['label'] }}</th>
 		{% endif %}
 		<td>
-			<a href="/{{ contentPath }}/{{ targetItem.id | slugify }}">{{ targetItem.title }}</a>
+			<a href="/{{ contentPath }}/{{ targetItem.data.id | slugify }}">{{ targetItem.data.title }}</a>
 		</td>
 	</tr>
 {% endfor %}

--- a/src/islandty/ContentModels/Audio.js
+++ b/src/islandty/ContentModels/Audio.js
@@ -1,36 +1,8 @@
-const DefaultContentModel = require('./default.js');
-const mediaHelpers = require('../lib/MediaHelpers.js');
-const path = require('path');
+const MediaWithTracksModel = require('./MediaWithTracksModel.js');
 
-
-class AudioContentModel extends DefaultContentModel {
-  buildFilesList(item, inputMediaPath, outputDir) {
-    const files = super.buildFilesList(item, inputMediaPath, outputDir);
-
-    if (item['media:audio:field_track']) {
-      const trackStructure = mediaHelpers.parseFieldTrack(item['media:audio:field_track']);
-      const trackFiles = mediaHelpers.flattenTrackStructure(trackStructure);
-
-      Object.entries(trackFiles).forEach(([relPath, destPath]) => {
-        const srcPath = path.join(inputMediaPath, relPath);
-        // Preserve directory structure in destination path
-        files[srcPath] = destPath; // destPath already includes subdirectories
-      });
-    }
-
-    return files;
-  }
-
-  async updateFilePaths(item) {
-    await super.updateFilePaths(item);
-
-    if (item['media:audio:field_track']) {
-      const basePath = await this.storageHandler.getContentBasePath(item.id);
-      item['media:audio:field_track'] = mediaHelpers.updateTrackField(
-        item['media:audio:field_track'],
-        basePath
-      );
-    }
+class AudioContentModel extends MediaWithTracksModel {
+  constructor() {
+    super('media:audio:field_track');
   }
 }
 

--- a/src/islandty/ContentModels/Audio.js
+++ b/src/islandty/ContentModels/Audio.js
@@ -13,7 +13,8 @@ class AudioContentModel extends DefaultContentModel {
 
       Object.entries(trackFiles).forEach(([relPath, destPath]) => {
         const srcPath = path.join(inputMediaPath, relPath);
-        files[srcPath] = destPath;
+        // Preserve directory structure in destination path
+        files[srcPath] = destPath; // destPath already includes subdirectories
       });
     }
 

--- a/src/islandty/ContentModels/MediaWithTracksModel.js
+++ b/src/islandty/ContentModels/MediaWithTracksModel.js
@@ -1,0 +1,40 @@
+const path = require('path');
+const DefaultContentModel = require('./default.js');
+const mediaHelpers = require('../lib/MediaHelpers.js');
+
+class MediaWithTracksModel extends DefaultContentModel {
+  constructor(trackField) {
+    super();
+    this.trackField = trackField;
+  }
+
+  buildFilesList(item, inputMediaPath, outputDir) {
+    const files = super.buildFilesList(item, inputMediaPath, outputDir);
+
+    if (item[this.trackField]) {
+      const trackStructure = mediaHelpers.parseFieldTrack(item[this.trackField]);
+      const trackFiles = mediaHelpers.flattenTrackStructure(trackStructure);
+
+      Object.entries(trackFiles).forEach(([relPath, destPath]) => {
+        const srcPath = path.join(inputMediaPath, relPath);
+        files[srcPath] = destPath;
+      });
+    }
+
+    return files;
+  }
+
+  async updateFilePaths(item) {
+    await super.updateFilePaths(item);
+
+    if (item[this.trackField]) {
+      const basePath = await this.storageHandler.getContentBasePath(item.id);
+      item[this.trackField] = mediaHelpers.updateTrackField(
+        item[this.trackField],
+        basePath
+      );
+    }
+  }
+}
+
+module.exports = MediaWithTracksModel;

--- a/src/islandty/ContentModels/PageContentModel.js
+++ b/src/islandty/ContentModels/PageContentModel.js
@@ -1,0 +1,14 @@
+const DefaultContentModel = require('./default.js');
+
+class PageContentModel extends DefaultContentModel {
+  buildFilesList(item, inputMediaPath, outputDir) {
+    const files = super.buildFilesList(item, inputMediaPath, outputDir);
+
+    // Remove main page file from preservation storage (handled by parent)
+    delete files[path.join(inputMediaPath, item.file)];
+
+    return files;
+  }
+}
+
+module.exports = PageContentModel;

--- a/src/islandty/ContentModels/PagedContent.js
+++ b/src/islandty/ContentModels/PagedContent.js
@@ -6,101 +6,164 @@ const { getChildContent, generateIiifMetadata } = require('../../_data/islandtyH
 const readCSV = require('../../_data/readCSV.js');
 require('dotenv').config();
 
+
 class PagedContentModel extends DefaultContentModel {
   async ingest(item, inputMediaPath, outputDir) {
     console.log("Processing paged content model ingest");
 
     try {
-      // 1. Process core files through storage handler (preservation copies)
-      await super.ingest(item, inputMediaPath, outputDir);
-
-      // 2. Always process IIIF derivatives to filesystem (working copies)
+      // Get child pages first
       const { items: allItems } = await readCSV();
-      const pages = getChildContent(allItems, item.id);
+      const pages = getChildContent(Object.values(allItems), item.id);
+
+      // First copy files to OCFL
+      const filesMap = super.buildFilesList(item, inputMediaPath, outputDir);
+      await this.addPageFiles(filesMap, pages, inputMediaPath);
+      await this.storageHandler.copyFiles(filesMap, inputMediaPath, outputDir);
+
+      // Then process IIIF after OCFL commit
+      const iiifPath = path.join(
+        process.env.outputDir,
+        process.env.contentPath,
+        item.id,
+        'iiif'
+      );
 
       if (pages.length > 0) {
-        const iiifPath = path.join(
-          process.env.outputDir,
-          process.env.contentPath,
-          item.id,
-          'iiif'
-        );
+        const needsIIIF = await this.checkIIIFNeeds(item, pages, iiifPath);
 
-        // Create IIIF directory structure and copy source files
-        await this.createIIIFStructure(pages, inputMediaPath, iiifPath);
-
-        // Generate IIIF metadata and build manifest
-        await this.processIIIFDerivatives(item, iiifPath);
+        if (needsIIIF) {
+          await this.createIIIFStructure(item, pages, inputMediaPath, iiifPath);
+          await this.processIIIFDerivatives(item, iiifPath);
+          await this.storeIIIFState(item, iiifPath);
+        }
       }
-
     } catch (err) {
       throw new Error(`Paged content ingestion failed: ${err.message}`);
     }
   }
 
-  buildFilesList(item, inputMediaPath, outputDir) {
-    const files = super.buildFilesList(item, inputMediaPath, outputDir);
-    this.addPageFiles(files, item, inputMediaPath);
-    return files;
-  }
+  async addPageFiles(filesMap, pages, inputMediaPath) {
+    console.log('Adding page files to OCFL preservation:');
 
-  async addPageFiles(files, item, inputMediaPath) {
-    try {
-      const { items: allItems } = await readCSV();
-      const pages = getChildContent(allItems, item.id);
+    for (const [index, page] of pages.entries()) {
+      if (page.file) {
+        const srcPath = path.join(inputMediaPath, page.file);
+        const fileName = `pages/${index.toString().padStart(4, '0')}_${path.basename(page.file)}`;
 
-      for (const page of pages) {
-        if (page.file) {
-          const inputFile = path.join(inputMediaPath, page.file);
-          const fileName = path.basename(page.file);
-
-          // Store in OCFL (if enabled) under pages directory
-          files[inputFile] = path.join('pages', fileName);
-
-          // Add hOCR files if they exist
-          const hocrFile = await this.findHocrFile(page, inputMediaPath);
-          if (hocrFile) {
-            files[hocrFile] = path.join('pages', path.basename(hocrFile));
-          }
+        console.log(`- Preserving ${srcPath} => ${fileName}`);
+        filesMap[srcPath] = fileName;
+        // Add hOCR file if exists
+        const hocrFile = await this.findHocrFile(page, inputMediaPath);
+        if (hocrFile) {
+          const hocrBaseName = path.basename(hocrFile);
+          const hocrFileName = `pages/${index.toString().padStart(4, '0')}_${hocrBaseName}`;
+          filesMap[hocrFile] = hocrFileName;
         }
       }
-    } catch (err) {
-      console.error('Error adding page files:', err);
     }
   }
 
-  async createIIIFStructure(pages, inputMediaPath, iiifPath) {
+  async checkIIIFNeeds(item, pages, iiifPath) {
+    if (!this.storageHandler.isOCFL()) return true;
+
     try {
-      // Process pages sequentially to maintain order
-      for (const page of pages) {
-        if (page.file) {
-          const inputFile = path.join(inputMediaPath, page.file);
-          const fileName = path.basename(inputFile);
-          const baseName = fileName.replace(/\.[^/.]+$/, "");
-          const pageOutputPath = path.join(iiifPath, `_${baseName}`);
+      const version = await this.getLatestOcflVersion(item.id);
+      const iiifVersionFile = path.join(iiifPath, '.ocfl-version');
 
-          // Create underscored directory
-          await fs.mkdir(pageOutputPath, { recursive: true });
-
-          // Copy main file to IIIF working directory
-          const destFile = path.join(pageOutputPath, fileName);
-          await fs.copyFile(inputFile, destFile);
-
-          // Copy hOCR file if exists
-          const hocrFile = await this.findHocrFile(page, inputMediaPath);
-          if (hocrFile) {
-            const hocrFileName = path.basename(hocrFile);
-            const hocrDest = path.join(pageOutputPath, hocrFileName);
-            await fs.copyFile(hocrFile, hocrDest);
-          }
-        }
+      try {
+        const storedVersion = await fs.readFile(iiifVersionFile, 'utf8');
+        return storedVersion.trim() !== version;
+      } catch {
+        return true; // Version file missing
       }
-    } catch (err) {
-      console.error('Error creating IIIF structure:', err);
-      throw err;
+    } catch (error) {
+      console.error('Error checking IIIF needs:', error);
+      return true; // Force rebuild on error
     }
   }
 
+  async storeIIIFState(item, iiifPath) {
+    if (this.storageHandler.isOCFL()) {
+      const object = this.storageHandler.storage.object(item.id);
+      const inventory = await object.getInventory();
+      await fs.writeFile(path.join(iiifPath, '.ocfl-version'), inventory.head);
+    }
+  }
+
+
+
+  async createIIIFStructure(item, pages, inputMediaPath, iiifPath) {
+    // Get actual version from OCFL
+    const version = await this.getLatestOcflVersion(item.id);
+    const ocflContentPath = path.join(
+      process.env.outputDir,
+      'ocfl-files',
+      item.id,
+      version,
+      'content'
+    );
+
+    // Copy files from OCFL to IIIF directory
+    for (const [index, page] of pages.entries()) {
+      if (!page.file) continue;
+
+      const baseName = path.basename(page.file, path.extname(page.file));
+      const underscoredDir = `_${baseName}`;
+      const iiifPageDir = path.join(iiifPath, underscoredDir);
+
+      await fs.mkdir(iiifPageDir, { recursive: true });
+
+      // Construct source path using OCFL-preserved files
+      const ocflImagePath = path.join(
+        ocflContentPath,
+        'pages',
+        `${index.toString().padStart(4, '0')}_${path.basename(page.file)}`
+      );
+
+      // Verify file exists before copying
+      try {
+        await fs.access(ocflImagePath);
+      } catch {
+        throw new Error(`Missing OCFL file: ${ocflImagePath}`);
+      }
+
+      const iiifImagePath = path.join(iiifPageDir, path.basename(page.file));
+      await fs.copyFile(ocflImagePath, iiifImagePath);
+
+      // Copy hOCR file if exists
+      const hocrFile = await this.findHocrFile(page, inputMediaPath);
+      if (hocrFile) {
+        const hocrFileName = path.basename(hocrFile);
+        const ocflHocrPath = path.join(ocflContentPath, `pages/${index.toString().padStart(4, '0')}_${hocrFileName}`);
+        const iiifHocrPath = path.join(iiifPageDir, hocrFileName);
+        await fs.copyFile(ocflHocrPath, iiifHocrPath);
+      }
+    }
+  }
+
+  async getLatestOcflVersion(objectId) {
+    try {
+      const object = this.storageHandler.storage.object(objectId);
+      const inventory = await object.getInventory();
+      return inventory.head;
+    } catch (error) {
+      return 'v1'; // Fallback for new objects
+    }
+  }
+
+  async storeIIIFState(item, iiifPath) {
+    if (this.storageHandler.isOCFL()) {
+      try {
+        const version = await this.getLatestOcflVersion(item.id);
+        await fs.writeFile(path.join(iiifPath, '.ocfl-version'), version);
+      } catch (error) {
+        console.error('Error storing IIIF state:', error);
+        // Fallback to writing v1 if version can't be determined
+        await fs.writeFile(path.join(iiifPath, '.ocfl-version'), 'v1');
+      }
+    }
+  }
 
   async findHocrFile(page, inputMediaPath) {
     if (page.hocr) return path.join(inputMediaPath, page.hocr);
@@ -146,7 +209,6 @@ class PagedContentModel extends DefaultContentModel {
   async updateFilePaths(item) {
     await super.updateFilePaths(item);
 
-    // Update IIIF manifest path
     if (item.iiifManifest) {
       item.iiifManifest = path.join(
         process.env.contentPath,
@@ -155,6 +217,9 @@ class PagedContentModel extends DefaultContentModel {
         'manifest.json'
       );
     }
+
+    // Add direct link to IIIF manifest
+    item.iiif_manifest_url = `${process.env.serverHost}/${item.iiifManifest}`;
   }
 }
 

--- a/src/islandty/ContentModels/PublicationIssue.js
+++ b/src/islandty/ContentModels/PublicationIssue.js
@@ -1,25 +1,8 @@
-const path = require('path');
-const { promises: fs } = require('fs');
-const defaultContentModel = require('./default.js');
-const { ingest } = require('./PagedContent.js'); // Reuse core functionality
-require('dotenv').config();
+const PagedContentModel = require('./PagedContent.js');
 
-module.exports = {
-  async ingest(item, inputMediaPath, outputDir) {
-    try {
-      // Reuse IIIF processing from PagedContent
-      await ingest(item, inputMediaPath, outputDir);
+class PublicationIssueModel extends PagedContentModel {
+  // Inherits all functionality from PagedContentModel
+  // Add any publication-specific overrides here if needed
+}
 
-      // Add any PublicationIssue-specific processing here
-
-      // Process default ingestion
-      await defaultContentModel.ingest(item, inputMediaPath, outputDir);
-    } catch (err) {
-      throw new Error(`Publication issue ingestion failed: ${err.message}`);
-    }
-  },
-
-  async updateFilePaths(item) {
-    defaultContentModel.updateFilePaths(item);
-  }
-};
+module.exports = PublicationIssueModel;

--- a/src/islandty/ContentModels/Video.js
+++ b/src/islandty/ContentModels/Video.js
@@ -1,34 +1,8 @@
-const path = require('path');
-const DefaultContentModel = require('./default.js');
-const mediaHelpers = require('../lib/MediaHelpers.js');
+const MediaWithTracksModel = require('./MediaWithTracksModel.js');
 
-class VideoContentModel extends DefaultContentModel {
-  buildFilesList(item, inputMediaPath, outputDir) {
-    const files = super.buildFilesList(item, inputMediaPath, outputDir);
-
-    if (item['media:video:field_track']) {
-      const trackStructure = mediaHelpers.parseFieldTrack(item['media:video:field_track']);
-      const trackFiles = mediaHelpers.flattenTrackStructure(trackStructure);
-
-      Object.entries(trackFiles).forEach(([relPath, destPath]) => {
-        const srcPath = path.join(inputMediaPath, relPath);
-        files[srcPath] = destPath;
-      });
-    }
-
-    return files;
-  }
-
-  async updateFilePaths(item) {
-    await super.updateFilePaths(item);
-
-    if (item['media:video:field_track']) {
-      const basePath = await this.storageHandler.getContentBasePath(item.id);
-      item['media:video:field_track'] = mediaHelpers.updateTrackField(
-        item['media:video:field_track'],
-        basePath
-      );
-    }
+class VideoContentModel extends MediaWithTracksModel {
+  constructor() {
+    super('media:video:field_track');
   }
 }
 

--- a/src/islandty/ContentModels/default.js
+++ b/src/islandty/ContentModels/default.js
@@ -1,18 +1,20 @@
+// src/islandty/ContentModels/default.js
 const path = require('path');
 const islandtyHelpers = require('../../_data/islandtyHelpers.js');
 const { createStorageHandler } = require('../storageHandler');
 require('dotenv').config();
 
-module.exports = {
+class DefaultContentModel {
   async init() {
-    this.storageHandler = await createStorageHandler(process.env.storageConfig ?
-      JSON.parse(process.env.storageConfig) : {});
+    this.storageHandler = await createStorageHandler(
+      process.env.storageConfig ? JSON.parse(process.env.storageConfig) : {}
+    );
     return this;
-  },
+  }
 
   async ingest(item, inputMediaPath, outputDir) {
     await this.storageHandler.copyFiles(item, inputMediaPath, outputDir);
-  },
+  }
 
   async updateFilePaths(item) {
     const fileFields = islandtyHelpers.getFileFields();
@@ -27,9 +29,11 @@ module.exports = {
     if (item.extracted) {
       item.extractedText = await this.readExtractedText(item);
     }
-  },
+  }
 
   async readExtractedText(item) {
     // Implementation that works with both storage backends
   }
-};
+}
+
+module.exports = DefaultContentModel;

--- a/src/islandty/ContentModels/default.js
+++ b/src/islandty/ContentModels/default.js
@@ -1,12 +1,12 @@
 const path = require('path');
 const islandtyHelpers = require('../../_data/islandtyHelpers.js');
 const { createStorageHandler } = require('../storageHandler');
-require('dotenv').config();
+require('dotenv');
 
 class DefaultContentModel {
   async init() {
     this.storageHandler = await createStorageHandler(
-      process.env.storageConfig ? JSON.parse(process.env.storageConfig) : {}
+      process.env.ocfl
     );
     return this;
   }

--- a/src/islandty/ContentModels/default.js
+++ b/src/islandty/ContentModels/default.js
@@ -1,4 +1,3 @@
-// src/islandty/ContentModels/default.js
 const path = require('path');
 const islandtyHelpers = require('../../_data/islandtyHelpers.js');
 const { createStorageHandler } = require('../storageHandler');
@@ -13,12 +12,31 @@ class DefaultContentModel {
   }
 
   async ingest(item, inputMediaPath, outputDir) {
-    await this.storageHandler.copyFiles(item, inputMediaPath, outputDir);
+    const files = this.buildFilesList(item, inputMediaPath, outputDir);
+    await this.storageHandler.copyFiles(files, inputMediaPath, outputDir);
+  }
+
+  buildFilesList(item, inputMediaPath, outputDir) {
+    const files = {};
+    const fileFields = islandtyHelpers.getFileFields();
+
+    fileFields.forEach(field => {
+      if (item[field]?.trim()) {
+        const srcPath = path.join(inputMediaPath, item[field]);
+        const fileName = path.basename(item[field]);
+        files[srcPath] = fileName;
+      }
+    });
+
+    return files;
   }
 
   async updateFilePaths(item) {
     const fileFields = islandtyHelpers.getFileFields();
-
+    // Handle extracted text
+    if (item.extracted) {
+      //item.extractedText = await fs.readFile(path.join(process.env.outputDir, item['extracted']), { encoding: 'utf8' });
+    }
     for (const field of fileFields) {
       if (item[field]?.trim()) {
         const fileName = path.basename(item[field]);
@@ -26,13 +44,6 @@ class DefaultContentModel {
       }
     }
 
-    if (item.extracted) {
-      item.extractedText = await this.readExtractedText(item);
-    }
-  }
-
-  async readExtractedText(item) {
-    // Implementation that works with both storage backends
   }
 }
 

--- a/src/islandty/ContentModels/default.js
+++ b/src/islandty/ContentModels/default.js
@@ -33,10 +33,7 @@ class DefaultContentModel {
 
   async updateFilePaths(item) {
     const fileFields = islandtyHelpers.getFileFields();
-    // Handle extracted text
-    if (item.extracted) {
-      //item.extractedText = await fs.readFile(path.join(process.env.outputDir, item['extracted']), { encoding: 'utf8' });
-    }
+
     for (const field of fileFields) {
       if (item[field]?.trim()) {
         const fileName = path.basename(item[field]);

--- a/src/islandty/ContentModels/default.js
+++ b/src/islandty/ContentModels/default.js
@@ -1,58 +1,26 @@
-const fs = require('fs').promises;
 const path = require('path');
-const islandtyFieldInfo = require('../../../config/islandtyFieldInfo.json');
-const islandtyHelpers = require('../../_data/islandtyHelpers.js')
+const islandtyHelpers = require('../../_data/islandtyHelpers.js');
+const { createStorageHandler } = require('../storageHandler');
 require('dotenv').config();
 
-const fileFields = islandtyHelpers.getFileFields();
-
 module.exports = {
-  /**
-   * Async version of file ingestion
-   */
+  async init() {
+    this.storageHandler = await createStorageHandler(process.env.storageConfig ?
+      JSON.parse(process.env.storageConfig) : {});
+    return this;
+  },
+
   async ingest(item, inputMediaPath, outputDir) {
     try {
-      // Create output directory if it doesn't exist
-      await fs.mkdir(outputDir, { recursive: true });
-
-      // Process all file fields in parallel
-      await Promise.all(fileFields.map(async (fileField) => {
-        if (item[fileField] && item[fileField] !== "" && item[fileField] !== 'False') {
-          const inputFile = path.join(inputMediaPath, item[fileField]);
-          const fileName = path.basename(inputFile);
-          const outputPath = path.join(outputDir, fileName);
-
-          try {
-            await fs.copyFile(inputFile, outputPath);
-            console.log(`Successfully copied ${outputPath}`);
-          } catch (err) {
-            console.error(`Error copying ${outputPath}:`, err);
-            throw err; // Rethrow to catch in outer try/catch
-          }
-        }
-      }));
-
-      return true; // Indicate success
+      await this.storageHandler.copyFiles(item, inputMediaPath, outputDir);
+      return true;
     } catch (error) {
       console.error('Error in ingest:', error);
-      throw error; // Propagate error to caller
+      throw error;
     }
   },
 
-  /**
-   * Synchronous path updates (no async needed)
-   */
   async updateFilePaths(item) {
-    fileFields.forEach((fileField) => {
-      if (item[fileField] && item[fileField] !== "" && item[fileField] !== 'False') {
-        const outputDir = path.join(process.env.contentPath, item.id);
-        const fileName = path.basename(item[fileField]);
-        item[fileField] = `/${path.join(outputDir, fileName)}`;
-      }
-    });
-    if (item['extracted']) {
-      extractedText = await fs.readFile(path.join(process.env.outputDir, item['extracted']), { encoding: 'utf8'});
-      item['extractedText'] = extractedText;
-    }
+    await this.storageHandler.updateFilePaths(item);
   }
 };

--- a/src/islandty/ContentModels/default.js
+++ b/src/islandty/ContentModels/default.js
@@ -11,16 +11,25 @@ module.exports = {
   },
 
   async ingest(item, inputMediaPath, outputDir) {
-    try {
-      await this.storageHandler.copyFiles(item, inputMediaPath, outputDir);
-      return true;
-    } catch (error) {
-      console.error('Error in ingest:', error);
-      throw error;
-    }
+    await this.storageHandler.copyFiles(item, inputMediaPath, outputDir);
   },
 
   async updateFilePaths(item) {
-    await this.storageHandler.updateFilePaths(item);
+    const fileFields = islandtyHelpers.getFileFields();
+
+    for (const field of fileFields) {
+      if (item[field]?.trim()) {
+        const fileName = path.basename(item[field]);
+        item[field] = await this.storageHandler.getFullContentPath(item.id, fileName);
+      }
+    }
+
+    if (item.extracted) {
+      item.extractedText = await this.readExtractedText(item);
+    }
+  },
+
+  async readExtractedText(item) {
+    // Implementation that works with both storage backends
   }
 };

--- a/src/islandty/ContentModels/image.js
+++ b/src/islandty/ContentModels/image.js
@@ -1,28 +1,25 @@
-const fs = require('fs').promises;
 const path = require('path');
-const defaultContentModel = require('./default.js');
-require('dotenv').config();
+const DefaultContentModel = require('./default.js');
 
-module.exports = {
-  /**
-   * Async version of ingest that properly awaits the default model
-   */
+class ImageContentModel extends DefaultContentModel {
   async ingest(item, inputMediaPath, outputDir) {
     try {
-      // Await the async operation from the default model
-      await defaultContentModel.ingest(item, inputMediaPath, outputDir);
+      // Call parent ingest implementation
+      await super.ingest(item, inputMediaPath, outputDir);
+
+      // Add any image-specific file operations here
     } catch (err) {
-      console.error(`Error in media_audio ingest: ${err.message}`);
-      throw err; // Propagate the error
+      console.error(`Error in image content model ingest: ${err.message}`);
+      throw err;
     }
-  },
-
-  /**
-   *  Update File Paths after ingest.
-   */
-  async updateFilePaths(item) {
-
-    defaultContentModel.updateFilePaths(item);
-
   }
-};
+
+  async updateFilePaths(item) {
+    // Call parent implementation first
+    await super.updateFilePaths(item);
+
+    // Add any image-specific path updates here
+  }
+}
+
+module.exports = ImageContentModel;

--- a/src/islandty/commands/readCSV.js
+++ b/src/islandty/commands/readCSV.js
@@ -54,10 +54,9 @@ async function main() {
       const contentModel = new ContentModelClass();
       await contentModel.init();
 
-      // Ingest media files
+      // Process files using content model
       const objectOutputDir = path.join(process.env.outputDir, process.env.contentPath, item.id);
       await contentModel.ingest(item, inputMediaPath, objectOutputDir);
-      // Update file paths
       await contentModel.updateFilePaths(item);
 
       const transformedItem = islandtyHelpers.transformKeys(item, fieldInfo);

--- a/src/islandty/commands/readCSV.js
+++ b/src/islandty/commands/readCSV.js
@@ -42,16 +42,16 @@ async function main() {
         item.id = item.node_id;
       }
       let contentModelName = item.field_model.split(':').pop().replace(/\s+/g, '');
-      let contentModel;
+      let ContentModelClass;
 
       try {
-        contentModel = require(`../../islandty/ContentModels/${contentModelName}`);
+        ContentModelClass = require(`../../islandty/ContentModels/${contentModelName}`);
       } catch (e) {
         if (e.code !== 'MODULE_NOT_FOUND') throw e;
-        contentModel = require('../../islandty/ContentModels/default');
+        ContentModelClass = require('../../islandty/ContentModels/default');
       }
 
-      // Initialize content model with storage handler
+      const contentModel = new ContentModelClass();
       await contentModel.init();
 
       // Ingest media files

--- a/src/islandty/commands/readCSV.js
+++ b/src/islandty/commands/readCSV.js
@@ -51,9 +51,12 @@ async function main() {
         contentModel = require('../../islandty/ContentModels/default');
       }
 
+      // Initialize content model with storage handler
+      await contentModel.init();
+
       // Ingest media files
-            const objectOutputDir = path.join(process.env.outputDir, process.env.contentPath, item.id);
-            await contentModel.ingest(item, inputMediaPath, objectOutputDir);
+      const objectOutputDir = path.join(process.env.outputDir, process.env.contentPath, item.id);
+      await contentModel.ingest(item, inputMediaPath, objectOutputDir);
       // Update file paths
       await contentModel.updateFilePaths(item);
 

--- a/src/islandty/lib/MediaHelpers.js
+++ b/src/islandty/lib/MediaHelpers.js
@@ -3,6 +3,26 @@ const path = require('path');
 
 module.exports = {
 
+  flattenTrackStructure(trackStructure) {
+      const files = {};
+      const processNode = (node, pathParts = []) => {
+        for (const [key, value] of Object.entries(node)) {
+          const newPath = [...pathParts, key];
+          if (this.isDirectoryNode(value)) {
+            processNode(value, newPath);
+          } else {
+            const destPath = path.posix.join(...newPath);
+            for (const filePath of value) {
+              const fileName = path.posix.basename(filePath);
+              files[filePath] = path.posix.join(destPath, fileName);
+            }
+          }
+        }
+      };
+      processNode(trackStructure);
+      return files;
+    },
+
   parseFieldTrack(fieldTrackStr, trackFieldName) {
     const result = {};
 

--- a/src/islandty/storageHandler.js
+++ b/src/islandty/storageHandler.js
@@ -14,6 +14,10 @@ class StorageBase {
     throw new Error('Not implemented');
   }
 
+  isOCFL() {
+    return false;
+  }
+
   async updateFilePaths(item) {
     throw new Error('Not implemented');
   }
@@ -221,6 +225,10 @@ class OCFLStorage extends StorageBase {
     } catch (error) {
       return false;
     }
+  }
+
+  isOCFL() {
+    return true;
   }
 }
 

--- a/src/islandty/storageHandler.js
+++ b/src/islandty/storageHandler.js
@@ -40,9 +40,19 @@ class FileSystemStorage extends StorageBase {
   async copyFiles(filesMap, inputMediaPath, outputDir) {
     await fs.mkdir(outputDir, { recursive: true });
 
-    await Promise.all(Object.entries(filesMap).map(async ([srcPath, destFileName]) => {
-      const outputPath = path.join(outputDir, destFileName);
-      await fs.copyFile(srcPath, outputPath);
+    await Promise.all(Object.entries(filesMap).map(async ([srcPath, destPath]) => {
+      const fullDestPath = path.join(outputDir, destPath);
+      const destDir = path.dirname(fullDestPath);
+
+      try {
+        // Create directory structure if needed
+        await fs.mkdir(destDir, { recursive: true });
+        await fs.copyFile(srcPath, fullDestPath);
+        console.log(`Copied ${srcPath} to ${fullDestPath}`);
+      } catch (err) {
+        console.error(`Error copying ${srcPath}:`, err);
+        throw err;
+      }
     }));
   }
 

--- a/src/islandty/storageHandler.js
+++ b/src/islandty/storageHandler.js
@@ -246,12 +246,12 @@ class OCFLStorage extends StorageBase {
 module.exports = {
   FileSystemStorage,
   OCFLStorage,
-  createStorageHandler: async (config) => {
-    if (config?.ocfl === true) {
-      const handler = new OCFLStorage(config);
+  createStorageHandler: async (useOcfl) => {
+    if (useOcfl) {
+      const handler = new OCFLStorage({ "ocfl": true, "layout": "FlatDirectStorageLayout"});
       return handler.initialize();
     }
-    return new FileSystemStorage(config);
+    return new FileSystemStorage({"ocfl": false});
   }
 
 

--- a/src/islandty/storageHandler.js
+++ b/src/islandty/storageHandler.js
@@ -217,7 +217,7 @@ class OCFLStorage extends StorageBase {
   async objectExists(object) {
     try {
       const inventory = await object.getInventory();
-      return inventory !== null;
+      return !(!inventory);
     } catch (error) {
       return false;
     }

--- a/src/islandty/storageHandler.js
+++ b/src/islandty/storageHandler.js
@@ -1,0 +1,144 @@
+const fs = require('fs').promises;
+const path = require('path');
+const islandtyHelpers = require('../_data/islandtyHelpers.js');
+require('dotenv').config();
+
+class FileSystemStorage {
+  constructor(config = {}) {
+    this.config = config;
+  }
+
+  async copyFiles(item, inputMediaPath, outputDir) {
+    const fileFields = islandtyHelpers.getFileFields();
+
+    await fs.mkdir(outputDir, { recursive: true });
+
+    await Promise.all(fileFields.map(async (fileField) => {
+      if (item[fileField] && item[fileField] !== "" && item[fileField] !== 'False') {
+        const inputFile = path.join(inputMediaPath, item[fileField]);
+        const fileName = path.basename(inputFile);
+        const outputPath = path.join(outputDir, fileName);
+
+        try {
+          await fs.copyFile(inputFile, outputPath);
+          console.log(`Successfully copied ${outputPath}`);
+        } catch (err) {
+          console.error(`Error copying ${outputPath}:`, err);
+          throw err;
+        }
+      }
+    }));
+
+    return true;
+  }
+
+  async updateFilePaths(item) {
+    const fileFields = islandtyHelpers.getFileFields();
+    fileFields.forEach((fileField) => {
+      if (item[fileField] && item[fileField] !== "" && item[fileField] !== 'False') {
+        const fileName = path.basename(item[fileField]);
+        item[fileField] = `/${path.join(process.env.contentPath, item.id, fileName)}`;
+      }
+    });
+
+    if (item['extracted']) {
+      const extractedText = await fs.readFile(path.join(process.env.outputDir, item['extracted']), { encoding: 'utf8' });
+      item['extractedText'] = extractedText;
+    }
+  }
+}
+
+class OCFLStorage {
+  constructor(config = {}) {
+    this.config = config;
+    this.ocfl = require('@ocfl/ocfl-fs');
+    this.storage = null;
+    this.ocflWebRoot = path.join(process.env.outputDir, 'ocfl-files');
+  }
+
+  async initialize() {
+    try {
+      this.storage = await this.ocfl.createStorage({
+        root: this.ocflWebRoot,
+        layout: this.config.layout || 'FlatDirectStorageLayout'
+      });
+      console.log(`OCFL storage initialized at ${this.ocflWebRoot}`);
+    } catch (error) {
+      try {
+        this.storage = await this.ocfl.loadStorage({
+          root: this.ocflWebRoot
+        });
+        console.log(`Existing OCFL storage loaded from ${this.ocflWebRoot}`);
+      } catch (error) {
+        console.error('Failed to initialize OCFL storage:', error);
+        throw error;
+      }
+    }
+    return this;
+  }
+
+  async copyFiles(item, inputMediaPath, outputDir) {
+    if (!this.storage) await this.initialize();
+
+    const objectId = item.id;
+    const object = this.storage.object(objectId);
+
+    const fileFields = islandtyHelpers.getFileFields();
+    const importItems = [];
+
+    for (const fileField of fileFields) {
+      if (item[fileField] && item[fileField] !== "" && item[fileField] !== 'False') {
+        const inputFile = path.join(inputMediaPath, item[fileField]);
+        const fileName = path.basename(inputFile);
+        importItems.push([inputFile, fileName]);
+      }
+    }
+
+    try {
+      await object.import(importItems);
+      console.log(`Successfully imported files to OCFL object ${objectId}`);
+      return true;
+    } catch (err) {
+      console.error(`Error importing to OCFL object ${objectId}:`, err);
+      throw err;
+    }
+  }
+
+  async updateFilePaths(item) {
+    const fileFields = islandtyHelpers.getFileFields();
+
+    fileFields.forEach((fileField) => {
+      if (item[fileField] && item[fileField] !== "" && item[fileField] !== 'False') {
+        const fileName = path.basename(item[fileField]);
+        // Direct path to the file in OCFL structure
+        item[fileField] = `/ocfl-files/${item.id}/v1/content/${fileName}`;
+      }
+    });
+
+    if (item['extracted']) {
+      try {
+        const object = this.storage.object(item.id);
+        const extractedPath = path.basename(item['extracted']);
+        const extractedText = await object.read(extractedPath);
+        item['extractedText'] = extractedText.toString('utf8');
+        // Update extracted path to match OCFL structure
+        item['extracted'] = `/ocfl-files/${item.id}/v1/content/${extractedPath}`;
+      } catch (error) {
+        console.error(`Error reading extracted text from OCFL object ${item.id}:`, error);
+        item['extractedText'] = '';
+      }
+    }
+  }
+}
+
+module.exports = {
+  FileSystemStorage,
+  OCFLStorage,
+  createStorageHandler: async (config) => {
+    if (config?.ocfl === true) {
+      const handler = new OCFLStorage(config);
+      return handler.initialize();
+    }
+    return new FileSystemStorage(config);
+  }
+};


### PR DESCRIPTION
Related issue: #57 

This PR adds full OCFL support to Islandty.

When enabled, objects will be placed into OCFL containers. modificatoins to files are tracked and new versions are minted. Copying files and generating derivatives like IIIF tiles is skipped if no changes are detected, so this will significantly speed up Islandty when re-running it on an existing site.

## Testing 

To test, first run ```npm install```` since we've added the OCFL libraries ot the dependencies, then add the line:

```ini
ocfl=true
```

To your .env file.

Then run ```npm run clean``` followed by ```npm start```t, 